### PR TITLE
Feat/fix: wait for tx to resolve/reject using resolversMap

### DIFF
--- a/apps/extension/src/Approvals/Approvals.tsx
+++ b/apps/extension/src/Approvals/Approvals.tsx
@@ -43,7 +43,7 @@ export const Approvals: React.FC = () => {
   const requester = useRequester();
 
   // Logic for canceling transactions/signatures when closing the window using the close-button.
-  // Perhaps not the cleanest place to have this logic, neither is the shared variable (performUnloadCleanup).
+  // Not really the cleanest place to put this, neither is the use of a shared variable (performUnloadCleanup).
   // TODO: extract this logic, perhaps by creating a separate context.
   useEffect(() => {
     const onUnload = async () => {

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -80,16 +80,16 @@ const handleApproveTxMsg: (
 const handleRejectTxMsg: (
   service: ApprovalsService
 ) => InternalHandler<RejectTxMsg> = (service) => {
-  return async (_, { msgId }) => {
-    return await service.rejectTx(msgId);
+  return async ({ senderTabId: popupTabId }, { msgId }) => {
+    return await service.rejectTx(popupTabId, msgId);
   };
 };
 
 const handleSubmitApprovedTxMsg: (
   service: ApprovalsService
 ) => InternalHandler<SubmitApprovedTxMsg> = (service) => {
-  return async (_, { msgId }) => {
-    return await service.submitTx(msgId);
+    return async ({ senderTabId: popupTabId }, { msgId }) => {
+    return await service.submitTx(popupTabId, msgId);
   };
 };
 

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -480,10 +480,12 @@ describe("approvals service", () => {
 
   describe("rejectTx", () => {
     it("should clear pending tx", async () => {
+      const tabId = 1;
+      
       jest.spyOn(service as any, "_clearPendingTx");
-      await service.rejectTx("msgId");
+      await service.rejectTx(tabId, "msgId");
 
-      expect((service as any)._clearPendingTx).toHaveBeenCalledWith("msgId");
+      expect((service as any)._clearPendingTx).toHaveBeenCalledWith(tabId, "msgId");
     });
   });
 });

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -68,7 +68,7 @@ export class ApprovalsService {
     });
 
     const popupTabId = await this.getPopupTabId(url);
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       this.resolverMap[popupTabId] = { resolve, reject };
     });
   }
@@ -145,7 +145,7 @@ export class ApprovalsService {
     });
 
     const popupTabId = await this.getPopupTabId(url);
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
         this.resolverMap[popupTabId] = { resolve, reject };
     });
   }

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -98,6 +98,7 @@ export class ApprovalsService {
   }
 
   async rejectSignature(popupTabId: number, msgId: string): Promise<void> {
+    this.isResolver(popupTabId);
     await this._clearPendingSignature(msgId);
     this.reject(popupTabId);
   }
@@ -193,6 +194,7 @@ export class ApprovalsService {
 
   // Remove pending transaction from storage
   async rejectTx(popupTabId: number, msgId: string): Promise<void> {
+    this.isResolver(popupTabId);
     await this._clearPendingTx(msgId);
     this.reject(popupTabId);
   }

--- a/apps/extension/src/utils/index.ts
+++ b/apps/extension/src/utils/index.ts
@@ -6,12 +6,25 @@ import { Result } from "@namada/utils";
 import { ISignature } from "@zondax/ledger-namada";
 
 /**
+ * This variable makes sure that pending tx/signature requests get rejected
+ * when set to true. See the use effect in src/approvals/Approvals.tsx.
+ * This gets set to false if the tab gets closed programmatically (i.e. when
+ * a transaction gets submitted).
+ */
+export let performUnloadCleanup = true;
+
+/**
  * Query the current extension tab and close it
  */
 export const closeCurrentTab = async (): Promise<void> => {
   const tab = await browser.tabs.getCurrent();
   if (tab.id) {
-    browser.tabs.remove(tab.id);
+    try {
+      performUnloadCleanup = false;
+      await browser.tabs.remove(tab.id);
+    } finally {
+      performUnloadCleanup = true;
+    }
   }
 };
 


### PR DESCRIPTION
Hi there!

So I'm currently working on the IBC shielded transfer app, which communicates with the Namada extension and stumbled upon the following problem:

_Sent transactions to the extension immediately resolve/reject, which make it impossible for the browser to wait for a result and decide whether the tx failed or not._

This PR solves this and also optimizes/fixes/restructures/refactors some of the resolver logic; see more technical details below.

With this fix the frontend is capable of awaiting sent transactions and also able to see whether the user approves or declines the transaction (or closes the window). Declining makes the browser aware of the promises' rejection with an optional message field, while a successful transaction resolves with optional additional details.

ZEN
