### PR TITLE
fix: assets in shielded rewards calculator

### DIFF
--- a/apps/namadillo/src/atoms/chain/services.ts
+++ b/apps/namadillo/src/atoms/chain/services.ts
@@ -50,9 +50,9 @@ export const fetchMaspRewards = async (
   const existingRewards: MaspAssetRewards[] = rewards
     .filter((r) => r.maxRewardRate > 0)
     .map((r) => {
-      const denom = getDenomFromIbcTrace(r.name);
       const asset =
-        assets.find((asset) => asset.base === denom) ?? unknownAsset(denom);
+        assets.find((asset) => asset.address === r.address) ??
+        unknownAsset(getDenomFromIbcTrace(r.name));
       return {
         asset,
         address: r.address,


### PR DESCRIPTION
## Before:
<img width="396" height="363" alt="image" src="https://github.com/user-attachments/assets/e33688ff-b447-4a98-89cd-b626a39d2439" />

## After:
<img width="325" height="417" alt="image" src="https://github.com/user-attachments/assets/40da85b7-ca11-41e5-9b39-1d3f49964fae" />
