### PR TITLE
fix: changed supported asset from NYX to NYM

### DIFF
--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -117,7 +117,7 @@ export const SUPPORTED_ASSETS_MAP = new Map<string, string[]>(
     osmosis: ["NAM", "OSMO"],
     cosmoshub: ["ATOM"],
     celestia: ["TIA"],
-    nyx: ["NYX"],
+    nyx: ["NYM"],
     stride: ["stOSMO", "stATOM", "stTIA"],
     neutron: ["NTRN"],
     noble: ["USDC"],


### PR DESCRIPTION
One line PR's are so silly. Should fix NYM not being selectable, see #2256.

PS: you could scratch this and edit it in a new PR if I screwed something up wrt the contribution guidelines!