### PR TITLE
chore: update rust version in dockerfiles

### DIFF
--- a/docker/faucet/Dockerfile
+++ b/docker/faucet/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.79 AS builder
+FROM rust:1.85.1 AS builder
 WORKDIR /app
 
 RUN apt update && apt install -y nodejs npm clang pkg-config libssl-dev protobuf-compiler curl

--- a/docker/namadillo/Dockerfile
+++ b/docker/namadillo/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.79 AS builder
+FROM rust:1.85.1 AS builder
 WORKDIR /app
 
 RUN apt update && apt install -y nodejs npm clang pkg-config libssl-dev protobuf-compiler curl


### PR DESCRIPTION
Otherwise we get this:
```
#26 88.19 Caused by: `cargo metadata` exited with an error:     Updating crates.io index
#26 88.19     Updating git repository `https://github.com/namada-net/namada`
#26 88.19 error: failed to get `namada_sdk` as a dependency of package `shared v0.1.0 (/app/packages/shared/lib)`
#26 88.19 
#26 88.19 Caused by:
#26 88.19   failed to load source for dependency `namada_sdk`
#26 88.19 
#26 88.19 Caused by:
#26 88.19   Unable to update https://github.com/namada-net/namada?tag=libs-v0.251.1#9785a72d
#26 88.19 
#26 88.19 Caused by:
#26 88.19   failed to parse manifest at `/usr/local/cargo/git/checkouts/namada-a7dd000410f87378/9785a72/wasm/tx_bond/Cargo.toml`
#26 88.19 
#26 88.19 Caused by:
#26 88.19   feature `edition2024` is required
#26 88.19 
#26 88.19   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.79.0 (ffa9cf99a 2024-06-03)).
#26 88.19   Consider trying a newer version of Cargo (this may require the nightly release).
#26 88.19   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
#26 88.19 
#26 DONE 88.8s
```