### PR TITLE
chore: only show dollar based balances if the dollar balances are available

### DIFF
--- a/apps/namadillo/src/App/AccountOverview/ShieldedAssetsOverview.tsx
+++ b/apps/namadillo/src/App/AccountOverview/ShieldedAssetsOverview.tsx
@@ -2,7 +2,6 @@ import { ActionButton, Panel } from "@namada/components";
 import { MaspSyncCover } from "App/Common/MaspSyncCover";
 import { ShieldedAssetTable } from "App/Masp/ShieldedAssetTable";
 import { routes } from "App/routes";
-import { shieldedTokensAtom } from "atoms/balance";
 import { applicationFeaturesAtom } from "atoms/settings";
 import clsx from "clsx";
 import { useAmountsInFiat } from "hooks/useAmountsInFiat";
@@ -13,12 +12,11 @@ import { TotalBalanceCard } from "./TotalBalanceCard";
 
 export const ShieldedAssetsOverview = (): JSX.Element => {
   const { shieldingRewardsEnabled } = useAtomValue(applicationFeaturesAtom);
-  const { shieldedAmountInFiat, shieldedQuery } = useAmountsInFiat();
+  const { shieldedAmountInFiat, shieldedQuery, hasShieldedAssets } =
+    useAmountsInFiat();
   const textContainerClassList = `flex h-full gap-1 items-center justify-center`;
   const requiresNewShieldedSync = useRequiresNewShieldedSync();
-  const shieldedTokensQuery = useAtomValue(shieldedTokensAtom);
-  const hasShieldedAssets =
-    shieldedTokensQuery.data?.some((token) => token.amount.gt(0)) ?? false;
+
   // Hide TotalBalanceCard if shielded fiat amount is 0 but shielded assets exist
   const shouldHideBalanceCard =
     shieldedQuery.isSuccess && hasShieldedAssets && shieldedAmountInFiat.eq(0);

--- a/apps/namadillo/src/App/AccountOverview/ShieldedAssetsOverview.tsx
+++ b/apps/namadillo/src/App/AccountOverview/ShieldedAssetsOverview.tsx
@@ -12,31 +12,38 @@ import { TotalBalanceCard } from "./TotalBalanceCard";
 
 export const ShieldedAssetsOverview = (): JSX.Element => {
   const { shieldingRewardsEnabled } = useAtomValue(applicationFeaturesAtom);
-  const { shieldedAmountInFiat } = useAmountsInFiat();
+  const { shieldedAmountInFiat, hasShieldedAssets, shieldedQuery } =
+    useAmountsInFiat();
   const textContainerClassList = `flex h-full gap-1 items-center justify-center`;
   const requiresNewShieldedSync = useRequiresNewShieldedSync();
+
+  // Hide TotalBalanceCard if shielded fiat amount is 0 but shielded assets exist
+  const shouldHideBalanceCard =
+    shieldedQuery.isSuccess && hasShieldedAssets && shieldedAmountInFiat.eq(0);
 
   return (
     <Panel className="relative px-6 border-x border-b border-yellow rounded-t-none h-full">
       <div className="flex justify-between gap-16 mt-4">
-        <TotalBalanceCard
-          balanceInFiat={shieldedAmountInFiat}
-          isShielded={true}
-          footerButtons={
-            <>
-              <ActionButton
-                href={routes.transfer}
-                outlineColor="yellow"
-                size="xs"
-                className="w-auto px-4"
-              >
-                <span className={clsx(textContainerClassList)}>
-                  Shielded Transfer
-                </span>
-              </ActionButton>
-            </>
-          }
-        />
+        {!shouldHideBalanceCard && (
+          <TotalBalanceCard
+            balanceInFiat={shieldedAmountInFiat}
+            isShielded={true}
+            footerButtons={
+              <>
+                <ActionButton
+                  href={routes.transfer}
+                  outlineColor="yellow"
+                  size="xs"
+                  className="w-auto px-4"
+                >
+                  <span className={clsx(textContainerClassList)}>
+                    Shielded Transfer
+                  </span>
+                </ActionButton>
+              </>
+            }
+          />
+        )}
         {shieldingRewardsEnabled && <EstimateShieldingRewardsCard />}
       </div>
       <div className="mt-10">

--- a/apps/namadillo/src/App/AccountOverview/ShieldedAssetsOverview.tsx
+++ b/apps/namadillo/src/App/AccountOverview/ShieldedAssetsOverview.tsx
@@ -2,6 +2,7 @@ import { ActionButton, Panel } from "@namada/components";
 import { MaspSyncCover } from "App/Common/MaspSyncCover";
 import { ShieldedAssetTable } from "App/Masp/ShieldedAssetTable";
 import { routes } from "App/routes";
+import { shieldedTokensAtom } from "atoms/balance";
 import { applicationFeaturesAtom } from "atoms/settings";
 import clsx from "clsx";
 import { useAmountsInFiat } from "hooks/useAmountsInFiat";
@@ -12,11 +13,12 @@ import { TotalBalanceCard } from "./TotalBalanceCard";
 
 export const ShieldedAssetsOverview = (): JSX.Element => {
   const { shieldingRewardsEnabled } = useAtomValue(applicationFeaturesAtom);
-  const { shieldedAmountInFiat, hasShieldedAssets, shieldedQuery } =
-    useAmountsInFiat();
+  const { shieldedAmountInFiat, shieldedQuery } = useAmountsInFiat();
   const textContainerClassList = `flex h-full gap-1 items-center justify-center`;
   const requiresNewShieldedSync = useRequiresNewShieldedSync();
-
+  const shieldedTokensQuery = useAtomValue(shieldedTokensAtom);
+  const hasShieldedAssets =
+    shieldedTokensQuery.data?.some((token) => token.amount.gt(0)) ?? false;
   // Hide TotalBalanceCard if shielded fiat amount is 0 but shielded assets exist
   const shouldHideBalanceCard =
     shieldedQuery.isSuccess && hasShieldedAssets && shieldedAmountInFiat.eq(0);
@@ -24,7 +26,7 @@ export const ShieldedAssetsOverview = (): JSX.Element => {
   return (
     <Panel className="relative px-6 border-x border-b border-yellow rounded-t-none h-full">
       <div className="flex justify-between gap-16 mt-4">
-        {!shouldHideBalanceCard && (
+        {!shouldHideBalanceCard ?
           <TotalBalanceCard
             balanceInFiat={shieldedAmountInFiat}
             isShielded={true}
@@ -43,7 +45,7 @@ export const ShieldedAssetsOverview = (): JSX.Element => {
               </>
             }
           />
-        )}
+        : <div />}
         {shieldingRewardsEnabled && <EstimateShieldingRewardsCard />}
       </div>
       <div className="mt-10">

--- a/apps/namadillo/src/App/AccountOverview/TotalBalanceBanner.tsx
+++ b/apps/namadillo/src/App/AccountOverview/TotalBalanceBanner.tsx
@@ -1,11 +1,7 @@
 import { Panel, SkeletonLoading, Stack, Tooltip } from "@namada/components";
 import { FiatCurrency } from "App/Common/FiatCurrency";
 import { MaspSyncIndicator } from "App/Layout/MaspSyncIndicator";
-import {
-  shieldedBalanceAtom,
-  shieldedTokensAtom,
-  transparentTokensAtom,
-} from "atoms/balance";
+import { shieldedBalanceAtom } from "atoms/balance";
 import { applicationFeaturesAtom } from "atoms/settings";
 import clsx from "clsx";
 import { useAmountsInFiat } from "hooks/useAmountsInFiat";
@@ -18,10 +14,14 @@ export const TotalBalanceBanner = (): JSX.Element => {
   const { isFetching: isShieldSyncing } = useAtomValue(shieldedBalanceAtom);
   const requiresNewShieldedSync = useRequiresNewShieldedSync();
   const shouldWaitForShieldedSync = requiresNewShieldedSync && isShieldSyncing;
-  const { shieldedQuery, unshieldedQuery, stakingQuery, totalAmountInFiat } =
-    useAmountsInFiat();
-  const transparentTokensQuery = useAtomValue(transparentTokensAtom);
-  const shieldedTokensQuery = useAtomValue(shieldedTokensAtom);
+  const {
+    shieldedQuery,
+    unshieldedQuery,
+    stakingQuery,
+    totalAmountInFiat,
+    hasUnshieldedAssets,
+    hasShieldedAssets,
+  } = useAmountsInFiat();
   const balancesHaveLoaded =
     shieldedQuery.isSuccess &&
     unshieldedQuery.isSuccess &&
@@ -29,12 +29,8 @@ export const TotalBalanceBanner = (): JSX.Element => {
   const hasErrors =
     shieldedQuery.isError && unshieldedQuery.isError && stakingQuery.isError;
   const balanceIsLoading = !balancesHaveLoaded && !hasErrors;
-
-  const hasUnshieldedAssets =
-    transparentTokensQuery.data?.some((token) => token.amount.gt(0)) ?? false;
-  const hasShieldedAssets =
-    shieldedTokensQuery.data?.some((token) => token.amount.gt(0)) ?? false;
   const hasAnyAssets = hasUnshieldedAssets || hasShieldedAssets;
+
   // Hide banner if totalAmountInFiat is 0 but we have assets (means pricing is unavailable)
   const shouldHideBanner =
     balancesHaveLoaded && hasAnyAssets && totalAmountInFiat.eq(0);

--- a/apps/namadillo/src/App/AccountOverview/TotalBalanceBanner.tsx
+++ b/apps/namadillo/src/App/AccountOverview/TotalBalanceBanner.tsx
@@ -14,8 +14,13 @@ export const TotalBalanceBanner = (): JSX.Element => {
   const { isFetching: isShieldSyncing } = useAtomValue(shieldedBalanceAtom);
   const requiresNewShieldedSync = useRequiresNewShieldedSync();
   const shouldWaitForShieldedSync = requiresNewShieldedSync && isShieldSyncing;
-  const { shieldedQuery, unshieldedQuery, stakingQuery, totalAmountInFiat } =
-    useAmountsInFiat();
+  const {
+    shieldedQuery,
+    unshieldedQuery,
+    stakingQuery,
+    totalAmountInFiat,
+    hasAnyAssets,
+  } = useAmountsInFiat();
 
   const balancesHaveLoaded =
     shieldedQuery.isSuccess &&
@@ -24,6 +29,12 @@ export const TotalBalanceBanner = (): JSX.Element => {
   const hasErrors =
     shieldedQuery.isError && unshieldedQuery.isError && stakingQuery.isError;
   const balanceIsLoading = !balancesHaveLoaded && !hasErrors;
+
+  // Hide banner if totalAmountInFiat is 0 but we have assets (means pricing is unavailable)
+  const shouldHideBanner =
+    balancesHaveLoaded && hasAnyAssets && totalAmountInFiat.eq(0);
+
+  if (shouldHideBanner) return <></>;
 
   return (
     <Panel className="py-4">

--- a/apps/namadillo/src/App/AccountOverview/TotalBalanceBanner.tsx
+++ b/apps/namadillo/src/App/AccountOverview/TotalBalanceBanner.tsx
@@ -1,7 +1,11 @@
 import { Panel, SkeletonLoading, Stack, Tooltip } from "@namada/components";
 import { FiatCurrency } from "App/Common/FiatCurrency";
 import { MaspSyncIndicator } from "App/Layout/MaspSyncIndicator";
-import { shieldedBalanceAtom } from "atoms/balance";
+import {
+  shieldedBalanceAtom,
+  shieldedTokensAtom,
+  transparentTokensAtom,
+} from "atoms/balance";
 import { applicationFeaturesAtom } from "atoms/settings";
 import clsx from "clsx";
 import { useAmountsInFiat } from "hooks/useAmountsInFiat";
@@ -14,14 +18,10 @@ export const TotalBalanceBanner = (): JSX.Element => {
   const { isFetching: isShieldSyncing } = useAtomValue(shieldedBalanceAtom);
   const requiresNewShieldedSync = useRequiresNewShieldedSync();
   const shouldWaitForShieldedSync = requiresNewShieldedSync && isShieldSyncing;
-  const {
-    shieldedQuery,
-    unshieldedQuery,
-    stakingQuery,
-    totalAmountInFiat,
-    hasAnyAssets,
-  } = useAmountsInFiat();
-
+  const { shieldedQuery, unshieldedQuery, stakingQuery, totalAmountInFiat } =
+    useAmountsInFiat();
+  const transparentTokensQuery = useAtomValue(transparentTokensAtom);
+  const shieldedTokensQuery = useAtomValue(shieldedTokensAtom);
   const balancesHaveLoaded =
     shieldedQuery.isSuccess &&
     unshieldedQuery.isSuccess &&
@@ -30,6 +30,11 @@ export const TotalBalanceBanner = (): JSX.Element => {
     shieldedQuery.isError && unshieldedQuery.isError && stakingQuery.isError;
   const balanceIsLoading = !balancesHaveLoaded && !hasErrors;
 
+  const hasUnshieldedAssets =
+    transparentTokensQuery.data?.some((token) => token.amount.gt(0)) ?? false;
+  const hasShieldedAssets =
+    shieldedTokensQuery.data?.some((token) => token.amount.gt(0)) ?? false;
+  const hasAnyAssets = hasUnshieldedAssets || hasShieldedAssets;
   // Hide banner if totalAmountInFiat is 0 but we have assets (means pricing is unavailable)
   const shouldHideBanner =
     balancesHaveLoaded && hasAnyAssets && totalAmountInFiat.eq(0);

--- a/apps/namadillo/src/App/AccountOverview/UnshieldedAssetsOverview.tsx
+++ b/apps/namadillo/src/App/AccountOverview/UnshieldedAssetsOverview.tsx
@@ -28,7 +28,7 @@ export const UnshieldedAssetsOverview = (): JSX.Element => {
   return (
     <Panel className="relative px-6 rounded-t-none h-full">
       <div className="flex justify-between items-center gap-16 mt-4">
-        {!shouldHideBalanceCard && (
+        {!shouldHideBalanceCard ?
           <TotalBalanceCard
             balanceInFiat={unshieldedAmountInFiat}
             footerButtons={
@@ -43,7 +43,7 @@ export const UnshieldedAssetsOverview = (): JSX.Element => {
               </>
             }
           />
-        )}
+        : <div />}
         <UnclaimedRewardsCard />
       </div>
       {transparentTokensQuery.isSuccess && (

--- a/apps/namadillo/src/App/AccountOverview/UnshieldedAssetsOverview.tsx
+++ b/apps/namadillo/src/App/AccountOverview/UnshieldedAssetsOverview.tsx
@@ -9,7 +9,8 @@ import { TotalBalanceCard } from "./TotalBalanceCard";
 import { UnshieldedAssetTable } from "./UnshieldedAssetTable";
 
 export const UnshieldedAssetsOverview = (): JSX.Element => {
-  const { unshieldedAmountInFiat } = useAmountsInFiat();
+  const { unshieldedAmountInFiat, hasUnshieldedAssets, unshieldedQuery } =
+    useAmountsInFiat();
   const navigate = useNavigate();
   const transparentTokensQuery = useAtomValue(transparentTokensAtom);
 
@@ -18,23 +19,31 @@ export const UnshieldedAssetsOverview = (): JSX.Element => {
     (transparentTokensQuery.fetchStatus === "idle" &&
       !transparentTokensQuery.isFetched);
 
+  // Hide TotalBalanceCard if unshielded fiat amount is 0 but unshielded assets exist
+  const shouldHideBalanceCard =
+    unshieldedQuery.isSuccess &&
+    hasUnshieldedAssets &&
+    unshieldedAmountInFiat.eq(0);
+
   return (
     <Panel className="relative px-6 rounded-t-none h-full">
       <div className="flex justify-between items-center gap-16 mt-4">
-        <TotalBalanceCard
-          balanceInFiat={unshieldedAmountInFiat}
-          footerButtons={
-            <>
-              <ActionButton
-                onClick={() => navigate(routes.shield)}
-                size="xs"
-                className="w-auto px-4"
-              >
-                Shield Assets
-              </ActionButton>
-            </>
-          }
-        />
+        {!shouldHideBalanceCard && (
+          <TotalBalanceCard
+            balanceInFiat={unshieldedAmountInFiat}
+            footerButtons={
+              <>
+                <ActionButton
+                  onClick={() => navigate(routes.shield)}
+                  size="xs"
+                  className="w-auto px-4"
+                >
+                  Shield Assets
+                </ActionButton>
+              </>
+            }
+          />
+        )}
         <UnclaimedRewardsCard />
       </div>
       {transparentTokensQuery.isSuccess && (

--- a/apps/namadillo/src/App/AccountOverview/UnshieldedAssetsOverview.tsx
+++ b/apps/namadillo/src/App/AccountOverview/UnshieldedAssetsOverview.tsx
@@ -9,19 +9,19 @@ import { TotalBalanceCard } from "./TotalBalanceCard";
 import { UnshieldedAssetTable } from "./UnshieldedAssetTable";
 
 export const UnshieldedAssetsOverview = (): JSX.Element => {
-  const { unshieldedAmountInFiat, hasUnshieldedAssets, unshieldedQuery } =
-    useAmountsInFiat();
   const navigate = useNavigate();
   const transparentTokensQuery = useAtomValue(transparentTokensAtom);
-
+  const { unshieldedAmountInFiat } = useAmountsInFiat();
   const isLoading =
     transparentTokensQuery.isLoading ||
     (transparentTokensQuery.fetchStatus === "idle" &&
       !transparentTokensQuery.isFetched);
 
+  const hasUnshieldedAssets =
+    transparentTokensQuery.data?.some((token) => token.amount.gt(0)) ?? false;
   // Hide TotalBalanceCard if unshielded fiat amount is 0 but unshielded assets exist
   const shouldHideBalanceCard =
-    unshieldedQuery.isSuccess &&
+    transparentTokensQuery.isSuccess &&
     hasUnshieldedAssets &&
     unshieldedAmountInFiat.eq(0);
 

--- a/apps/namadillo/src/App/AccountOverview/UnshieldedAssetsOverview.tsx
+++ b/apps/namadillo/src/App/AccountOverview/UnshieldedAssetsOverview.tsx
@@ -11,14 +11,12 @@ import { UnshieldedAssetTable } from "./UnshieldedAssetTable";
 export const UnshieldedAssetsOverview = (): JSX.Element => {
   const navigate = useNavigate();
   const transparentTokensQuery = useAtomValue(transparentTokensAtom);
-  const { unshieldedAmountInFiat } = useAmountsInFiat();
+  const { unshieldedAmountInFiat, hasUnshieldedAssets } = useAmountsInFiat();
   const isLoading =
     transparentTokensQuery.isLoading ||
     (transparentTokensQuery.fetchStatus === "idle" &&
       !transparentTokensQuery.isFetched);
 
-  const hasUnshieldedAssets =
-    transparentTokensQuery.data?.some((token) => token.amount.gt(0)) ?? false;
   // Hide TotalBalanceCard if unshielded fiat amount is 0 but unshielded assets exist
   const shouldHideBalanceCard =
     transparentTokensQuery.isSuccess &&

--- a/apps/namadillo/src/atoms/balance/atoms.ts
+++ b/apps/namadillo/src/atoms/balance/atoms.ts
@@ -263,9 +263,9 @@ export const shieldedTokensAtom = atomWithQuery<TokenBalance[]>((get) => {
       async () =>
         mapNamadaAssetsToTokenBalances(
           shieldedAssets.data ?? {},
-          tokenPrices.data ?? {}
+          tokenPrices.isSuccess ? (tokenPrices.data ?? {}) : {}
         ),
-      [shieldedAssets, tokenPrices]
+      [shieldedAssets]
     ),
   };
 });
@@ -320,10 +320,10 @@ export const transparentTokensAtom = atomWithQuery<TokenBalance[]>((get) => {
         Promise.resolve(
           mapNamadaAssetsToTokenBalances(
             transparentAssets.data ?? {},
-            tokenPrices.data ?? {}
+            tokenPrices.isSuccess ? (tokenPrices.data ?? {}) : {}
           )
         ),
-      [transparentAssets, tokenPrices]
+      [transparentAssets]
     ),
   };
 });

--- a/apps/namadillo/src/hooks/useAmountsInFiat.tsx
+++ b/apps/namadillo/src/hooks/useAmountsInFiat.tsx
@@ -17,6 +17,10 @@ type AmountsInFiatOutput = {
   unshieldedQuery: AtomWithQueryResult;
   stakingQuery: AtomWithQueryResult;
   isLoading: boolean;
+  hasAnyAssets: boolean;
+  hasShieldedAssets: boolean;
+  hasUnshieldedAssets: boolean;
+  hasStakingAssets: boolean;
 };
 
 export const useAmountsInFiat = (): AmountsInFiatOutput => {
@@ -61,6 +65,38 @@ export const useAmountsInFiat = (): AmountsInFiatOutput => {
     .plus(unshieldedDollars)
     .plus(stakingDollars);
 
+  const assetFlags = useMemo(() => {
+    // Check if there are any shielded assets with non-zero balance
+    const hasShieldedAssets = (shieldedTokensQuery.data ?? []).some((token) =>
+      token.amount.gt(0)
+    );
+
+    // Check if there are any transparent assets with non-zero balance
+    const hasUnshieldedAssets = (unshieldedTokensQuery.data ?? []).some(
+      (token) => token.amount.gt(0)
+    );
+
+    // Check if there are any staking amounts
+    const hasStakingAssets =
+      stakingTotalsQuery.data ?
+        stakingTotalsQuery.data.totalBonded.gt(0) ||
+        stakingTotalsQuery.data.totalUnbonded.gt(0) ||
+        stakingTotalsQuery.data.totalWithdrawable.gt(0)
+      : false;
+
+    return {
+      hasShieldedAssets,
+      hasUnshieldedAssets,
+      hasStakingAssets,
+      hasAnyAssets:
+        hasShieldedAssets || hasUnshieldedAssets || hasStakingAssets,
+    };
+  }, [
+    shieldedTokensQuery.data,
+    unshieldedTokensQuery.data,
+    stakingTotalsQuery.data,
+  ]);
+
   return {
     shieldedQuery: shieldedTokensQuery,
     unshieldedQuery: unshieldedTokensQuery,
@@ -69,6 +105,7 @@ export const useAmountsInFiat = (): AmountsInFiatOutput => {
     shieldedAmountInFiat: shieldedDollars,
     unshieldedAmountInFiat: unshieldedDollars,
     stakingAmountInFiat: stakingDollars,
+    ...assetFlags,
     isLoading:
       shieldedTokensQuery.isLoading ||
       unshieldedTokensQuery.isLoading ||

--- a/apps/namadillo/src/hooks/useAmountsInFiat.tsx
+++ b/apps/namadillo/src/hooks/useAmountsInFiat.tsx
@@ -17,10 +17,6 @@ type AmountsInFiatOutput = {
   unshieldedQuery: AtomWithQueryResult;
   stakingQuery: AtomWithQueryResult;
   isLoading: boolean;
-  hasAnyAssets: boolean;
-  hasShieldedAssets: boolean;
-  hasUnshieldedAssets: boolean;
-  hasStakingAssets: boolean;
 };
 
 export const useAmountsInFiat = (): AmountsInFiatOutput => {
@@ -65,38 +61,6 @@ export const useAmountsInFiat = (): AmountsInFiatOutput => {
     .plus(unshieldedDollars)
     .plus(stakingDollars);
 
-  const assetFlags = useMemo(() => {
-    // Check if there are any shielded assets with non-zero balance
-    const hasShieldedAssets = (shieldedTokensQuery.data ?? []).some((token) =>
-      token.amount.gt(0)
-    );
-
-    // Check if there are any transparent assets with non-zero balance
-    const hasUnshieldedAssets = (unshieldedTokensQuery.data ?? []).some(
-      (token) => token.amount.gt(0)
-    );
-
-    // Check if there are any staking amounts
-    const hasStakingAssets =
-      stakingTotalsQuery.data ?
-        stakingTotalsQuery.data.totalBonded.gt(0) ||
-        stakingTotalsQuery.data.totalUnbonded.gt(0) ||
-        stakingTotalsQuery.data.totalWithdrawable.gt(0)
-      : false;
-
-    return {
-      hasShieldedAssets,
-      hasUnshieldedAssets,
-      hasStakingAssets,
-      hasAnyAssets:
-        hasShieldedAssets || hasUnshieldedAssets || hasStakingAssets,
-    };
-  }, [
-    shieldedTokensQuery.data,
-    unshieldedTokensQuery.data,
-    stakingTotalsQuery.data,
-  ]);
-
   return {
     shieldedQuery: shieldedTokensQuery,
     unshieldedQuery: unshieldedTokensQuery,
@@ -105,7 +69,6 @@ export const useAmountsInFiat = (): AmountsInFiatOutput => {
     shieldedAmountInFiat: shieldedDollars,
     unshieldedAmountInFiat: unshieldedDollars,
     stakingAmountInFiat: stakingDollars,
-    ...assetFlags,
     isLoading:
       shieldedTokensQuery.isLoading ||
       unshieldedTokensQuery.isLoading ||

--- a/apps/namadillo/src/hooks/useAmountsInFiat.tsx
+++ b/apps/namadillo/src/hooks/useAmountsInFiat.tsx
@@ -16,6 +16,8 @@ type AmountsInFiatOutput = {
   shieldedQuery: AtomWithQueryResult;
   unshieldedQuery: AtomWithQueryResult;
   stakingQuery: AtomWithQueryResult;
+  hasShieldedAssets: boolean;
+  hasUnshieldedAssets: boolean;
   isLoading: boolean;
 };
 
@@ -61,6 +63,11 @@ export const useAmountsInFiat = (): AmountsInFiatOutput => {
     .plus(unshieldedDollars)
     .plus(stakingDollars);
 
+  const hasShieldedAssets =
+    shieldedTokensQuery.data?.some((token) => token.amount.gt(0)) ?? false;
+  const hasUnshieldedAssets =
+    unshieldedTokensQuery.data?.some((token) => token.amount.gt(0)) ?? false;
+
   return {
     shieldedQuery: shieldedTokensQuery,
     unshieldedQuery: unshieldedTokensQuery,
@@ -69,6 +76,8 @@ export const useAmountsInFiat = (): AmountsInFiatOutput => {
     shieldedAmountInFiat: shieldedDollars,
     unshieldedAmountInFiat: unshieldedDollars,
     stakingAmountInFiat: stakingDollars,
+    hasShieldedAssets,
+    hasUnshieldedAssets,
     isLoading:
       shieldedTokensQuery.isLoading ||
       unshieldedTokensQuery.isLoading ||


### PR DESCRIPTION
This makes it so that when we don't have prices for tokens the users can still see their tokens. 

Also prevents the UI from being too wonky when prices aren't available.

<!--

Make sure you have read CONTRIBUTING.md before submitting a pull request!

-->
